### PR TITLE
ZEAL-1350 Touch ID Label Position

### DIFF
--- a/PasscodeLock/Views/PasscodeLockView.xib
+++ b/PasscodeLock/Views/PasscodeLockView.xib
@@ -31,19 +31,19 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1wK-Ol-7mm">
-                    <rect key="frame" x="185" y="191.5" width="44" height="29"/>
+                    <rect key="frame" x="185" y="213.5" width="44" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HbT-GO-CPk">
-                    <rect key="frame" x="165.5" y="230.5" width="83.5" height="19.5"/>
+                    <rect key="frame" x="165.5" y="252.5" width="83.5" height="19.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <color key="textColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HcN-lo-9Jb" userLabel="Placeholders">
-                    <rect key="frame" x="133.5" y="280" width="147" height="16"/>
+                    <rect key="frame" x="133.5" y="292" width="147" height="16"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w14-Kb-Jnf" userLabel="Placeholder 1" customClass="PasscodeSignPlaceholderView" customModule="PasscodeLock" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
@@ -465,7 +465,7 @@
                 <constraint firstItem="RR4-5o-pli" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="J8o-Fg-mKp"/>
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="12" id="LrD-lR-N3s"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerX" secondItem="pLy-90-g1a" secondAttribute="centerX" id="MLY-Mh-BhE"/>
-                <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-30" id="OLY-LF-tHd"/>
+                <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-20" id="OLY-LF-tHd"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerX" secondItem="EUD-XB-0CR" secondAttribute="centerX" id="Ofc-zy-NxN"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="Qup-3g-Gux"/>
                 <constraint firstItem="PbJ-Y8-MMf" firstAttribute="centerX" secondItem="C9Z-3u-ohd" secondAttribute="centerX" id="R1h-wb-tm1"/>
@@ -482,11 +482,11 @@
                 <constraint firstItem="EUD-XB-0CR" firstAttribute="centerX" secondItem="WDx-aD-wJK" secondAttribute="centerX" id="bc8-gr-atX"/>
                 <constraint firstItem="cuq-ue-Jyj" firstAttribute="centerY" secondItem="CGh-ph-49t" secondAttribute="centerY" id="cP3-7V-c0h"/>
                 <constraint firstItem="CGh-ph-49t" firstAttribute="bottom" secondItem="C9Z-3u-ohd" secondAttribute="top" constant="-12" id="diZ-Kj-1hU"/>
-                <constraint firstItem="CGh-ph-49t" firstAttribute="top" secondItem="HcN-lo-9Jb" secondAttribute="bottom" constant="60" id="e2e-0y-DBK"/>
                 <constraint firstItem="f3V-ZL-HQk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="esm-ky-oED"/>
                 <constraint firstItem="EUD-XB-0CR" firstAttribute="centerY" secondItem="PbJ-Y8-MMf" secondAttribute="centerY" id="hG9-Sl-EO9"/>
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="i6j-iI-02e"/>
                 <constraint firstItem="RA8-jd-dag" firstAttribute="centerX" secondItem="RR4-5o-pli" secondAttribute="centerX" id="inw-ZS-osP"/>
+                <constraint firstItem="f3V-ZL-HQk" firstAttribute="top" secondItem="HcN-lo-9Jb" secondAttribute="bottom" constant="12" id="lMx-ej-Bqn"/>
                 <constraint firstItem="C9Z-3u-ohd" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="40" id="luj-6S-dgY"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="naK-56-qUf"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerY" secondItem="0CR-0R-0Nr" secondAttribute="centerY" id="o0A-rK-1SQ"/>

--- a/PasscodeLock/Views/PasscodeLockView.xib
+++ b/PasscodeLock/Views/PasscodeLockView.xib
@@ -31,19 +31,19 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1wK-Ol-7mm">
-                    <rect key="frame" x="185" y="183.5" width="44" height="29"/>
+                    <rect key="frame" x="185" y="191.5" width="44" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HbT-GO-CPk">
-                    <rect key="frame" x="165.5" y="222.5" width="83.5" height="19.5"/>
+                    <rect key="frame" x="165.5" y="230.5" width="83.5" height="19.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <color key="textColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HcN-lo-9Jb" userLabel="Placeholders">
-                    <rect key="frame" x="133.5" y="272" width="147" height="16"/>
+                    <rect key="frame" x="133.5" y="280" width="147" height="16"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w14-Kb-Jnf" userLabel="Placeholder 1" customClass="PasscodeSignPlaceholderView" customModule="PasscodeLock" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
@@ -156,7 +156,7 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cuq-ue-Jyj" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="67" y="348" width="80" height="80"/>
+                    <rect key="frame" x="67" y="356" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="1">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -181,7 +181,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CGh-ph-49t" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="167" y="348" width="80" height="80"/>
+                    <rect key="frame" x="167" y="356" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="2">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -206,7 +206,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pLy-90-g1a" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="267" y="348" width="80" height="80"/>
+                    <rect key="frame" x="267" y="356" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="3">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -306,7 +306,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RA8-jd-dag" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="67" y="548" width="80" height="80"/>
+                    <rect key="frame" x="67" y="540" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="7">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -331,7 +331,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PbJ-Y8-MMf" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="167" y="548" width="80" height="80"/>
+                    <rect key="frame" x="167" y="540" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="8">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -356,7 +356,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EUD-XB-0CR" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="267" y="548" width="80" height="80"/>
+                    <rect key="frame" x="267" y="540" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="9">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -381,7 +381,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0CR-0R-0Nr" customClass="PasscodeSignButton" customModule="PasscodeLock" customModuleProvider="target">
-                    <rect key="frame" x="167" y="648" width="80" height="80"/>
+                    <rect key="frame" x="167" y="632" width="80" height="80"/>
                     <fontDescription key="fontDescription" type="system" weight="light" pointSize="24"/>
                     <state key="normal" title="0">
                         <color key="titleColor" red="0.32941176470588235" green="0.44705882352941173" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -406,7 +406,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="etg-x7-Mx1">
-                    <rect key="frame" x="76.5" y="673.5" width="61" height="29"/>
+                    <rect key="frame" x="76.5" y="657.5" width="61" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <inset key="contentEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                     <state key="normal" title="Cancel">
@@ -417,7 +417,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H78-kl-y6L">
-                    <rect key="frame" x="278" y="673.5" width="58" height="29"/>
+                    <rect key="frame" x="278" y="657.5" width="58" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <inset key="contentEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                     <state key="normal" title="Delete">
@@ -441,7 +441,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f3V-ZL-HQk">
-                    <rect key="frame" x="16" y="312" width="382" height="20"/>
+                    <rect key="frame" x="16" y="320" width="382" height="20"/>
                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <color key="textColor" red="0.97647058823529409" green="0.41568627450980389" blue="0.41568627450980389" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -462,35 +462,38 @@
                 <constraint firstItem="RR4-5o-pli" firstAttribute="centerX" secondItem="cuq-ue-Jyj" secondAttribute="centerX" id="EsN-cG-KcQ"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="bottom" secondItem="HbT-GO-CPk" secondAttribute="top" constant="-10" id="F4T-j8-jQJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="FUQ-Nh-ox9"/>
+                <constraint firstItem="RR4-5o-pli" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="J8o-Fg-mKp"/>
+                <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="12" id="LrD-lR-N3s"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerX" secondItem="pLy-90-g1a" secondAttribute="centerX" id="MLY-Mh-BhE"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-30" id="OLY-LF-tHd"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerX" secondItem="EUD-XB-0CR" secondAttribute="centerX" id="Ofc-zy-NxN"/>
-                <constraint firstItem="EUD-XB-0CR" firstAttribute="top" secondItem="WDx-aD-wJK" secondAttribute="bottom" constant="20" id="Q3h-lx-rxt"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="Qup-3g-Gux"/>
                 <constraint firstItem="PbJ-Y8-MMf" firstAttribute="centerX" secondItem="C9Z-3u-ohd" secondAttribute="centerX" id="R1h-wb-tm1"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="16" id="RDw-W3-MpZ"/>
+                <constraint firstItem="RA8-jd-dag" firstAttribute="centerY" secondItem="PbJ-Y8-MMf" secondAttribute="centerY" id="RHb-pY-SgJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RgV-eT-vCl"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="30" id="STC-Oe-YVu"/>
-                <constraint firstItem="0CR-0R-0Nr" firstAttribute="top" secondItem="PbJ-Y8-MMf" secondAttribute="bottom" constant="20" id="Sah-YV-A2O"/>
+                <constraint firstItem="0CR-0R-0Nr" firstAttribute="top" secondItem="PbJ-Y8-MMf" secondAttribute="bottom" constant="12" id="Sah-YV-A2O"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="VMo-hv-2qR"/>
-                <constraint firstItem="PbJ-Y8-MMf" firstAttribute="top" secondItem="C9Z-3u-ohd" secondAttribute="bottom" constant="20" id="Vo4-YP-n8O"/>
+                <constraint firstItem="PbJ-Y8-MMf" firstAttribute="top" secondItem="C9Z-3u-ohd" secondAttribute="bottom" constant="12" id="Vo4-YP-n8O"/>
                 <constraint firstItem="HcN-lo-9Jb" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Wqo-IM-yCU"/>
                 <constraint firstItem="pLy-90-g1a" firstAttribute="top" secondItem="CGh-ph-49t" secondAttribute="top" id="XXL-dB-dNT"/>
-                <constraint firstItem="WDx-aD-wJK" firstAttribute="top" secondItem="pLy-90-g1a" secondAttribute="bottom" constant="20" id="a7m-oE-Ygy"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="16" id="bR1-VP-TdA"/>
                 <constraint firstItem="EUD-XB-0CR" firstAttribute="centerX" secondItem="WDx-aD-wJK" secondAttribute="centerX" id="bc8-gr-atX"/>
-                <constraint firstItem="CGh-ph-49t" firstAttribute="bottom" secondItem="C9Z-3u-ohd" secondAttribute="top" constant="-20" id="diZ-Kj-1hU"/>
+                <constraint firstItem="cuq-ue-Jyj" firstAttribute="centerY" secondItem="CGh-ph-49t" secondAttribute="centerY" id="cP3-7V-c0h"/>
+                <constraint firstItem="CGh-ph-49t" firstAttribute="bottom" secondItem="C9Z-3u-ohd" secondAttribute="top" constant="-12" id="diZ-Kj-1hU"/>
                 <constraint firstItem="CGh-ph-49t" firstAttribute="top" secondItem="HcN-lo-9Jb" secondAttribute="bottom" constant="60" id="e2e-0y-DBK"/>
                 <constraint firstItem="f3V-ZL-HQk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="esm-ky-oED"/>
+                <constraint firstItem="EUD-XB-0CR" firstAttribute="centerY" secondItem="PbJ-Y8-MMf" secondAttribute="centerY" id="hG9-Sl-EO9"/>
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="i6j-iI-02e"/>
                 <constraint firstItem="RA8-jd-dag" firstAttribute="centerX" secondItem="RR4-5o-pli" secondAttribute="centerX" id="inw-ZS-osP"/>
                 <constraint firstItem="C9Z-3u-ohd" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="40" id="luj-6S-dgY"/>
-                <constraint firstItem="RA8-jd-dag" firstAttribute="top" secondItem="RR4-5o-pli" secondAttribute="bottom" constant="20" id="mfW-ld-bDO"/>
+                <constraint firstItem="WDx-aD-wJK" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="naK-56-qUf"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerY" secondItem="0CR-0R-0Nr" secondAttribute="centerY" id="o0A-rK-1SQ"/>
+                <constraint firstItem="pLy-90-g1a" firstAttribute="centerY" secondItem="CGh-ph-49t" secondAttribute="centerY" id="rmN-ES-ivF"/>
                 <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="f3V-ZL-HQk" secondAttribute="trailing" constant="16" id="sAu-ql-xzb"/>
                 <constraint firstItem="etg-x7-Mx1" firstAttribute="centerY" secondItem="0CR-0R-0Nr" secondAttribute="centerY" id="uxL-V3-wEY"/>
                 <constraint firstItem="etg-x7-Mx1" firstAttribute="centerX" secondItem="RA8-jd-dag" secondAttribute="centerX" id="v5R-tE-Ub7"/>
-                <constraint firstItem="RR4-5o-pli" firstAttribute="top" secondItem="cuq-ue-Jyj" secondAttribute="bottom" constant="20" id="ymC-lk-DI6"/>
             </constraints>
             <variation key="default">
                 <mask key="constraints">

--- a/PasscodeLock/Views/PasscodeLockView.xib
+++ b/PasscodeLock/Views/PasscodeLockView.xib
@@ -431,7 +431,10 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Ph-dj-v7R" userLabel="TouchID Button">
-                    <rect key="frame" x="159.5" y="850" width="95" height="26"/>
+                    <rect key="frame" x="159.5" y="832" width="95" height="44"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="44" id="Kz8-no-hKn"/>
+                    </constraints>
                     <inset key="contentEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                     <state key="normal" title="Use TouchID">
                         <color key="titleColor" red="0.4549019608" green="0.59999999999999998" blue="0.89411764709999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -463,7 +466,7 @@
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="bottom" secondItem="HbT-GO-CPk" secondAttribute="top" constant="-10" id="F4T-j8-jQJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="FUQ-Nh-ox9"/>
                 <constraint firstItem="RR4-5o-pli" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="J8o-Fg-mKp"/>
-                <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="12" id="LrD-lR-N3s"/>
+                <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="8" id="LrD-lR-N3s"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerX" secondItem="pLy-90-g1a" secondAttribute="centerX" id="MLY-Mh-BhE"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-20" id="OLY-LF-tHd"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerX" secondItem="EUD-XB-0CR" secondAttribute="centerX" id="Ofc-zy-NxN"/>
@@ -487,7 +490,7 @@
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="i6j-iI-02e"/>
                 <constraint firstItem="RA8-jd-dag" firstAttribute="centerX" secondItem="RR4-5o-pli" secondAttribute="centerX" id="inw-ZS-osP"/>
                 <constraint firstItem="f3V-ZL-HQk" firstAttribute="top" secondItem="HcN-lo-9Jb" secondAttribute="bottom" constant="12" id="lMx-ej-Bqn"/>
-                <constraint firstItem="C9Z-3u-ohd" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="40" id="luj-6S-dgY"/>
+                <constraint firstItem="C9Z-3u-ohd" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" priority="750" constant="40" id="luj-6S-dgY"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="naK-56-qUf"/>
                 <constraint firstItem="H78-kl-y6L" firstAttribute="centerY" secondItem="0CR-0R-0Nr" secondAttribute="centerY" id="o0A-rK-1SQ"/>
                 <constraint firstItem="pLy-90-g1a" firstAttribute="centerY" secondItem="CGh-ph-49t" secondAttribute="centerY" id="rmN-ES-ivF"/>

--- a/PasscodeLock/Views/PasscodeLockView.xib
+++ b/PasscodeLock/Views/PasscodeLockView.xib
@@ -466,7 +466,7 @@
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="bottom" secondItem="HbT-GO-CPk" secondAttribute="top" constant="-10" id="F4T-j8-jQJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="FUQ-Nh-ox9"/>
                 <constraint firstItem="RR4-5o-pli" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="J8o-Fg-mKp"/>
-                <constraint firstItem="1wK-Ol-7mm" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="Jsj-Ux-qoB"/>
+                <constraint firstItem="1wK-Ol-7mm" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="Jsj-Ux-qoB"/>
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="8" id="LrD-lR-N3s"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerX" secondItem="pLy-90-g1a" secondAttribute="centerX" id="MLY-Mh-BhE"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-20" id="OLY-LF-tHd"/>

--- a/PasscodeLock/Views/PasscodeLockView.xib
+++ b/PasscodeLock/Views/PasscodeLockView.xib
@@ -466,6 +466,7 @@
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="bottom" secondItem="HbT-GO-CPk" secondAttribute="top" constant="-10" id="F4T-j8-jQJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="FUQ-Nh-ox9"/>
                 <constraint firstItem="RR4-5o-pli" firstAttribute="centerY" secondItem="C9Z-3u-ohd" secondAttribute="centerY" id="J8o-Fg-mKp"/>
+                <constraint firstItem="1wK-Ol-7mm" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="Jsj-Ux-qoB"/>
                 <constraint firstItem="0Ph-dj-v7R" firstAttribute="top" relation="greaterThanOrEqual" secondItem="0CR-0R-0Nr" secondAttribute="bottom" constant="8" id="LrD-lR-N3s"/>
                 <constraint firstItem="WDx-aD-wJK" firstAttribute="centerX" secondItem="pLy-90-g1a" secondAttribute="centerX" id="MLY-Mh-BhE"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="bottom" secondItem="HcN-lo-9Jb" secondAttribute="top" constant="-20" id="OLY-LF-tHd"/>
@@ -475,7 +476,6 @@
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="trailing" constant="16" id="RDw-W3-MpZ"/>
                 <constraint firstItem="RA8-jd-dag" firstAttribute="centerY" secondItem="PbJ-Y8-MMf" secondAttribute="centerY" id="RHb-pY-SgJ"/>
                 <constraint firstItem="HbT-GO-CPk" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RgV-eT-vCl"/>
-                <constraint firstItem="1wK-Ol-7mm" firstAttribute="top" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="top" constant="30" id="STC-Oe-YVu"/>
                 <constraint firstItem="0CR-0R-0Nr" firstAttribute="top" secondItem="PbJ-Y8-MMf" secondAttribute="bottom" constant="12" id="Sah-YV-A2O"/>
                 <constraint firstItem="1wK-Ol-7mm" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="VMo-hv-2qR"/>
                 <constraint firstItem="PbJ-Y8-MMf" firstAttribute="top" secondItem="C9Z-3u-ohd" secondAttribute="bottom" constant="12" id="Vo4-YP-n8O"/>


### PR DESCRIPTION
- Added vertical spacing constraint between the zero button and Use TouchID button
- Reduced vertical spacing between number buttons
- Updated outer number buttons to use alignment constraints to make updates easier
- Added fixed height to TouchId button
- Updated centre button alignment priority
- Removed/readded title label top constraint and adjusted the constant

iPhone SE
![simulator_screenshot_BBF49B4D-A28F-4BE3-A37F-1B8D75E7F0EF](https://user-images.githubusercontent.com/87641055/130088763-e6bf7442-c487-4f6f-95be-2468e9379237.png)

